### PR TITLE
testing: add htmlproofer script

### DIFF
--- a/htmlproofer_test.rb
+++ b/htmlproofer_test.rb
@@ -1,0 +1,17 @@
+require 'html-proofer'
+
+options = {
+  assume_extension: true,
+  check_img_http: true,
+  check_html: true,
+  empty_alt_ignore: true,
+  disable_external: true,
+  allow_hash_href: true,
+  check_opengraph: true,
+  only_4xx: true,
+  http_status_ignore: [429,403],
+  parallel: { in_processes: 8 },
+  cache: { timeframe: '6w' },
+}
+
+HTMLProofer.check_directory("./_site", options).run


### PR DESCRIPTION
can be executed as:
bundle exec ruby htmlproofer_test.rb

verifying that generated html and links are not broken.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>